### PR TITLE
fix: use fstream to copy file cross mount dir

### DIFF
--- a/deployment/dev/build.sh
+++ b/deployment/dev/build.sh
@@ -74,8 +74,8 @@ NO_COLOR="\033[0m"
 DOCKER_REG="secretflow"
 
 
-IMAGE_TAG=${DOCKER_REG}/teeapps-sim:${VERSION}
-LATEST_TAG=${DOCKER_REG}/teeapps-sim:latest
+IMAGE_TAG=${DOCKER_REG}/teeapps-sim-ubuntu20.04:${VERSION}
+LATEST_TAG=${DOCKER_REG}/teeapps-sim-ubuntu20.04:latest
 echo -e "Building ${GREEN}${IMAGE_TAG}${NO_COLOR}"
 cd ../.. && docker build . -f deployment/dev/Dockerfile -t ${IMAGE_TAG} \
   --build-arg config_templates="$(cat deployment/dev/config_templates.yml)" \

--- a/deployment/prod/build.sh
+++ b/deployment/prod/build.sh
@@ -74,8 +74,8 @@ NO_COLOR="\033[0m"
 DOCKER_REG="secretflow"
 
 
-IMAGE_TAG=${DOCKER_REG}/teeapps-sgx:${VERSION}
-LATEST_TAG=${DOCKER_REG}/teeapps-sgx:latest
+IMAGE_TAG=${DOCKER_REG}/teeapps-sgx-ubuntu20.04:${VERSION}
+LATEST_TAG=${DOCKER_REG}/teeapps-sgx-ubuntu20.04:latest
 echo -e "Building ${GREEN}${IMAGE_TAG}${NO_COLOR}"
 cd ../.. && docker build . -f deployment/prod/Dockerfile -t ${IMAGE_TAG} \
   --build-arg config_templates="$(cat deployment/prod/config_templates.yml)" \

--- a/teeapps/framework/app.cc
+++ b/teeapps/framework/app.cc
@@ -360,8 +360,7 @@ void App::ProcessOutput() {
       const std::string output_full_path =
           storage_config_.local_fs().wd() + "/" + output_uri;
       // upload result
-      std::filesystem::remove(output_full_path);
-      std::filesystem::copy(local_res_path, output_full_path);
+      teeapps::utils::CopyFile(local_res_path, output_full_path);
     }
   } else if (app_mode_ == teeapps::framework::kAppModeLocal) {
     for (const auto& uri : node_eval_param_.output_uris()) {
@@ -370,8 +369,7 @@ void App::ProcessOutput() {
       const std::string local_res_path = teeapps::utils::GenDataPath(output_id);
       const std::string output_full_path = output_uri;
       //  upload result
-      std::filesystem::remove(output_full_path);
-      std::filesystem::copy(local_res_path, output_full_path);
+      teeapps::utils::CopyFile(local_res_path, output_full_path);
     }
   } else {
     YACL_THROW("app mode {} not support", app_mode_);

--- a/teeapps/utils/io_util.cc
+++ b/teeapps/utils/io_util.cc
@@ -40,7 +40,8 @@ void WriteFile(const std::string& file_path, yacl::ByteContainerView content) {
 void CopyFile(const std::string& src_file_path,
               const std::string& dst_file_path) {
   std::ifstream source_file(src_file_path.c_str(), std::ios::binary);
-  std::ofstream dst_file(dst_file_path.c_str(), std::ios::binary | std::ios::trunc);
+  std::ofstream dst_file(dst_file_path.c_str(),
+                         std::ios::binary | std::ios::trunc);
   YACL_ENFORCE(source_file, "open source file fail.");
   YACL_ENFORCE(dst_file, "open dst file fail.");
   dst_file << source_file.rdbuf();

--- a/teeapps/utils/io_util.cc
+++ b/teeapps/utils/io_util.cc
@@ -40,7 +40,7 @@ void WriteFile(const std::string& file_path, yacl::ByteContainerView content) {
 void CopyFile(const std::string& src_file_path,
               const std::string& dst_file_path) {
   std::ifstream source_file(src_file_path.c_str(), std::ios::binary);
-  std::ofstream dst_file(dst_file_path.c_str(), std::ios::binary);
+  std::ofstream dst_file(dst_file_path.c_str(), std::ios::binary | std::ios::trunc);
   YACL_ENFORCE(source_file, "open source file fail.");
   YACL_ENFORCE(dst_file, "open dst file fail.");
   dst_file << source_file.rdbuf();

--- a/teeapps/utils/io_util.cc
+++ b/teeapps/utils/io_util.cc
@@ -14,6 +14,8 @@
 
 #include "teeapps/utils/io_util.h"
 
+#include <fstream>
+
 #include "yacl/base/byte_container_view.h"
 #include "yacl/io/stream/file_io.h"
 
@@ -33,6 +35,17 @@ void WriteFile(const std::string& file_path, yacl::ByteContainerView content) {
   yacl::io::FileOutputStream out(file_path);
   out.Write(content.data(), content.size());
   out.Close();
+}
+
+void CopyFile(const std::string& src_file_path,
+              const std::string& dst_file_path) {
+  std::ifstream source_file(src_file_path.c_str(), std::ios::binary);
+  std::ofstream dst_file(dst_file_path.c_str(), std::ios::binary);
+  YACL_ENFORCE(source_file, "open source file fail.");
+  YACL_ENFORCE(dst_file, "open dst file fail.");
+  dst_file << source_file.rdbuf();
+  source_file.close();
+  dst_file.close();
 }
 
 void MergeVerticalCsv(const std::string& left_file_path,

--- a/teeapps/utils/io_util.h
+++ b/teeapps/utils/io_util.h
@@ -23,6 +23,9 @@ std::string ReadFile(const std::string& file_path);
 
 void WriteFile(const std::string& file_path, yacl::ByteContainerView content);
 
+void CopyFile(const std::string& src_file_path,
+              const std::string& dst_file_path);
+
 void MergeVerticalCsv(const std::string& left_file_path,
                       const std::string& right_file_path,
                       const std::string& dest_file_path);


### PR DESCRIPTION
std::filesystem::copy won't work when copy file to a mounted dir in docker 24.0.6
use fstream to copy result file instead